### PR TITLE
add support for OpenAPI 3.0 specification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
       </dependency>
       <dependency>
         <groupId>com.epages</groupId>
+        <artifactId>restdocs-api-spec-openapi3-generator</artifactId>
+        <version>${restdocs-api-spec.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.epages</groupId>
         <artifactId>restdocs-api-spec-model</artifactId>
         <version>${restdocs-api-spec.version}</version>
       </dependency>

--- a/restdocs-spec-generator/pom.xml
+++ b/restdocs-spec-generator/pom.xml
@@ -21,6 +21,10 @@
     </dependency>
     <dependency>
       <groupId>com.epages</groupId>
+      <artifactId>restdocs-api-spec-openapi3-generator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.epages</groupId>
       <artifactId>restdocs-api-spec-model</artifactId>
     </dependency>
     <dependency>

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/Specification.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/Specification.java
@@ -6,7 +6,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 public enum Specification {
-  OPENAPI_V2("openapi-2.0", SpecificationFormat.YAML, SpecificationFormat.JSON);
+  OPENAPI_V2("openapi-2.0", SpecificationFormat.YAML, SpecificationFormat.JSON),
+  OPENAPI_V3("openapi-3.0", SpecificationFormat.YAML, SpecificationFormat.JSON);
 
   private final String defaultFilename;
   private final SpecificationFormat defaultFormat;

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/SpecificationGeneratorUtils.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/SpecificationGeneratorUtils.java
@@ -1,0 +1,34 @@
+package com.berkleytechnologyservices.restdocs.spec.generator;
+
+import com.berkleytechnologyservices.restdocs.spec.AuthConfig;
+import com.berkleytechnologyservices.restdocs.spec.Scope;
+import com.epages.restdocs.apispec.model.Oauth2Configuration;
+
+import java.util.stream.Collectors;
+
+public class SpecificationGeneratorUtils {
+
+  private SpecificationGeneratorUtils() {
+  }
+
+  public static Oauth2Configuration createOauth2Configuration(AuthConfig authConfig) {
+
+    Oauth2Configuration oauth2Configuration = null;
+
+    if (authConfig.getTokenUrl() != null && authConfig.getAuthorizationUrl() != null) {
+      oauth2Configuration = new Oauth2Configuration();
+      oauth2Configuration.setTokenUrl(authConfig.getTokenUrl());
+      oauth2Configuration.setAuthorizationUrl(authConfig.getAuthorizationUrl());
+      oauth2Configuration.setFlows(authConfig.getFlows().toArray(new String[0]));
+
+      if (!authConfig.getScopes().isEmpty()) {
+        oauth2Configuration.setScopes(
+                authConfig.getScopes().stream()
+                        .collect(Collectors.toMap(Scope::getName, Scope::getDescription))
+        );
+      }
+    }
+
+    return oauth2Configuration;
+  }
+}

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v2/OpenApi20SpecificationGenerator.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v2/OpenApi20SpecificationGenerator.java
@@ -5,6 +5,7 @@ import com.berkleytechnologyservices.restdocs.spec.AuthConfig;
 import com.berkleytechnologyservices.restdocs.spec.Scope;
 import com.berkleytechnologyservices.restdocs.spec.Specification;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGenerator;
+import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorUtils;
 import com.epages.restdocs.apispec.model.Oauth2Configuration;
 import com.epages.restdocs.apispec.model.ResourceModel;
 import com.epages.restdocs.apispec.openapi2.OpenApi20Generator;
@@ -40,29 +41,9 @@ public class OpenApi20SpecificationGenerator implements SpecificationGenerator {
         details.getSchemes(),
         details.getName(),
         details.getVersion(),
-        createOauth2Configuration(details.getAuthConfig()),
+        SpecificationGeneratorUtils.createOauth2Configuration(details.getAuthConfig()),
         details.getFormat().name().toLowerCase()
     );
   }
 
-  private static Oauth2Configuration createOauth2Configuration(AuthConfig authConfig) {
-
-    Oauth2Configuration oauth2Configuration = null;
-
-    if (authConfig.getTokenUrl() != null && authConfig.getAuthorizationUrl() != null) {
-      oauth2Configuration = new Oauth2Configuration();
-      oauth2Configuration.setTokenUrl(authConfig.getTokenUrl());
-      oauth2Configuration.setAuthorizationUrl(authConfig.getAuthorizationUrl());
-      oauth2Configuration.setFlows(authConfig.getFlows().toArray(new String[0]));
-
-      if (!authConfig.getScopes().isEmpty()) {
-        oauth2Configuration.setScopes(
-            authConfig.getScopes().stream()
-                .collect(Collectors.toMap(Scope::getName, Scope::getDescription))
-        );
-      }
-    }
-
-    return oauth2Configuration;
-  }
 }

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGenerator.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGenerator.java
@@ -1,0 +1,61 @@
+package com.berkleytechnologyservices.restdocs.spec.generator.openapi_v3;
+
+import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
+import com.berkleytechnologyservices.restdocs.spec.AuthConfig;
+import com.berkleytechnologyservices.restdocs.spec.Scope;
+import com.berkleytechnologyservices.restdocs.spec.Specification;
+import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGenerator;
+import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorUtils;
+import com.epages.restdocs.apispec.model.Oauth2Configuration;
+import com.epages.restdocs.apispec.model.ResourceModel;
+import com.epages.restdocs.apispec.openapi3.OpenApi3Generator;
+import io.swagger.v3.oas.models.servers.Server;
+
+import javax.inject.Named;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Named
+public class OpenApi30SpecificationGenerator implements SpecificationGenerator {
+
+  private final OpenApi3Generator generator;
+
+  public OpenApi30SpecificationGenerator() {
+    this(OpenApi3Generator.INSTANCE);
+  }
+
+  public OpenApi30SpecificationGenerator(OpenApi3Generator generator) {
+    this.generator = generator;
+  }
+
+  @Override
+  public Specification getSpecification() {
+    return Specification.OPENAPI_V3;
+  }
+
+  @Override
+  public String generate(ApiDetails details, List<ResourceModel> models) {
+    List<Server> servers = new ArrayList<>();
+    for (String scheme : details.getSchemes()) {
+      try {
+        URL url = new URL(scheme, details.getHost(), details.getBasePath() == null ? "" : details.getBasePath());
+        servers.add(new Server().url(url.toString()));
+      } catch (MalformedURLException e) {
+      	throw new IllegalArgumentException("Invalid server URL", e);
+      }
+    }
+    return generator.generateAndSerialize(
+            models,
+            servers,
+            details.getName(),
+            details.getVersion(),
+            SpecificationGeneratorUtils.createOauth2Configuration(details.getAuthConfig()),
+            details.getFormat().name().toLowerCase()
+    );
+  }
+
+}

--- a/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGeneratorTest.java
+++ b/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGeneratorTest.java
@@ -1,0 +1,73 @@
+package com.berkleytechnologyservices.restdocs.spec.generator.openapi_v3;
+
+import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
+import com.berkleytechnologyservices.restdocs.spec.Specification;
+import com.berkleytechnologyservices.restdocs.spec.generator.openapi_v2.OpenApi20SpecificationGenerator;
+import com.epages.restdocs.apispec.model.HTTPMethod;
+import com.epages.restdocs.apispec.model.ResourceModel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static com.berkleytechnologyservices.restdocs.spec.generator.test.ResourceModels.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.assertj.core.util.Lists.list;
+
+@ExtendWith(MockitoExtension.class)
+public class OpenApi30SpecificationGeneratorTest {
+
+  private final OpenApi30SpecificationGenerator generator = new OpenApi30SpecificationGenerator();
+
+  @Test
+  public void testGetSpecification() {
+    assertThat(generator.getSpecification()).isEqualTo(Specification.OPENAPI_V3);
+  }
+
+  @Test
+  public void testGenerateWithDefaults() {
+
+    ApiDetails apiDetails = new ApiDetails();
+
+    ResourceModel model = resource(
+            "book-get",
+            "Get a book by id",
+            "book",
+            request(
+                    "/book/{id}",
+                    HTTPMethod.GET,
+                    list(
+                            requiredParam("id", "The unique identifier for the book.", "NUMBER")
+                    ),
+                    emptyList()
+            ),
+            response(
+                    200,
+                    "application/hal+json",
+                    list(),
+                    list(
+                            field("title", "Title of the book", "STRING"),
+                            field("author", "Author of the book", "STRING"),
+                            field("pages", "Number of pages in the book", "NUMBER")
+                    ),
+                    "The example response.",
+                    "type: string"
+
+            )
+    );
+
+    String rawOutput = generator.generate(apiDetails, list(model));
+
+    assertThat(rawOutput)
+            .isEqualToNormalizingNewlines(contentOfResource("/mock-specs/default-settings-openapi3.yml"));
+  }
+
+  private static String contentOfResource(String resourceName) {
+    return contentOf(OpenApi30SpecificationGeneratorTest.class.getResource(resourceName));
+  }
+}

--- a/restdocs-spec-generator/src/test/resources/mock-specs/default-settings-openapi3.yml
+++ b/restdocs-spec-generator/src/test/resources/mock-specs/default-settings-openapi3.yml
@@ -1,0 +1,43 @@
+openapi: 3.0.1
+info:
+  title: API Documentation
+  version: 1.0.0
+servers:
+- url: http://localhost
+paths:
+  /book/{id}:
+    get:
+      tags:
+      - book
+      summary: Get a book by id
+      description: Get a book by id
+      operationId: book-get
+      parameters:
+      - name: id
+        in: path
+        description: The unique identifier for the book.
+        required: true
+      responses:
+        200:
+          description: "200"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/book-id328345809'
+              examples:
+                book-get:
+                  value: The example response.
+components:
+  schemas:
+    book-id328345809:
+      type: object
+      properties:
+        pages:
+          type: number
+          description: Number of pages in the book
+        author:
+          type: string
+          description: Author of the book
+        title:
+          type: string
+          description: Title of the book


### PR DESCRIPTION
closes  #16

OpenAPI 3 specifcation can be enabled by setting the ``specification`` configuration entry to ``OPENAPI_V3``

````xml
<configuration>
    <specification>OPENAPI_V3</specification>
</configuration>
````