### PR TITLE
Update restdocs-api-spec to 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.version>3.3.1</maven.version>
     <maven-plugin-tools.version>3.5.2</maven-plugin-tools.version>
-    <restdocs-api-spec.version>0.5.0</restdocs-api-spec.version>
+    <restdocs-api-spec.version>0.8.0</restdocs-api-spec.version>
     <junit.version>5.2.0</junit.version>
     <assertj.version>3.11.0</assertj.version>
     <mockito.version>2.21.0</mockito.version>

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/ApiDetails.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/ApiDetails.java
@@ -2,6 +2,7 @@ package com.berkleytechnologyservices.restdocs.spec;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class ApiDetails {
 
@@ -13,11 +14,13 @@ public class ApiDetails {
 
   private String name;
   private String version;
+  private String description;
   private String host;
   private String basePath;
   private List<String> schemes;
   private SpecificationFormat format;
   private AuthConfig authConfig;
+  private Map<String, String> tagDescriptions;
   
   public ApiDetails() {
     this.name = DEFAULT_NAME;
@@ -27,6 +30,7 @@ public class ApiDetails {
     this.schemes = DEFAULT_SCHEMES;
     this.format = DEFAULT_FORMAT;
     this.authConfig = new AuthConfig();
+    this.tagDescriptions = Collections.emptyMap();
   }
 
   public String getName() {
@@ -44,6 +48,15 @@ public class ApiDetails {
 
   public ApiDetails version(String version) {
     this.version = version != null ? version : DEFAULT_VERSION;
+    return this;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public ApiDetails description(String description){
+    this.description = description;
     return this;
   }
 
@@ -89,6 +102,15 @@ public class ApiDetails {
 
   public ApiDetails authConfig(AuthConfig authConfig) {
     this.authConfig = authConfig != null ? authConfig : new AuthConfig();
+    return this;
+  }
+
+  public Map<String, String> getTagDescriptions() {
+    return tagDescriptions;
+  }
+
+  public ApiDetails tagDescriptions(Map<String, String> tagDescriptions) {
+    this.tagDescriptions = tagDescriptions;
     return this;
   }
 }

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/ApiDetails.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/ApiDetails.java
@@ -110,7 +110,7 @@ public class ApiDetails {
   }
 
   public ApiDetails tagDescriptions(Map<String, String> tagDescriptions) {
-    this.tagDescriptions = tagDescriptions;
+    this.tagDescriptions = tagDescriptions != null ? tagDescriptions : this.tagDescriptions;
     return this;
   }
 }

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v2/OpenApi20SpecificationGenerator.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v2/OpenApi20SpecificationGenerator.java
@@ -39,6 +39,8 @@ public class OpenApi20SpecificationGenerator implements SpecificationGenerator {
         details.getHost(),
         details.getSchemes(),
         details.getName(),
+        details.getDescription(),
+        details.getTagDescriptions(),
         details.getVersion(),
         createOauth2Configuration(details.getAuthConfig()),
         details.getFormat().name().toLowerCase()

--- a/restdocs-spec-generator/src/test/resources/mock-specs/default-settings.yml
+++ b/restdocs-spec-generator/src/test/resources/mock-specs/default-settings.yml
@@ -3,6 +3,7 @@ info:
   version: 1.0.0
   title: API Documentation
 host: localhost
+tags: []
 schemes:
 - http
 paths:

--- a/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/GenerateMojo.java
+++ b/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/GenerateMojo.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -42,6 +43,12 @@ public class GenerateMojo extends AbstractMojo {
    */
   @Parameter(defaultValue = "${project.version}", required = true)
   private String version;
+
+  /**
+   * Description of the API
+   */
+  @Parameter(defaultValue = "${project.description}", required = true)
+  private String description;
 
   /**
    * Host
@@ -107,6 +114,14 @@ public class GenerateMojo extends AbstractMojo {
 
   @Parameter
   private AuthConfig oauth2 = new AuthConfig();
+
+  /**
+   * Mapping of tag names to descriptions. These are populated into the top level.
+   * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#tag-object>https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#tag-object</a>
+   * No default - if not provided no tags will be created.
+   */
+  @Parameter
+  private Map<String, String> tagDescriptions;
 
   private final SnippetReader snippetReader;
   private final SpecificationGeneratorFactory specificationGeneratorFactory;
@@ -201,11 +216,13 @@ public class GenerateMojo extends AbstractMojo {
     return new ApiDetails()
         .name(name)
         .version(version)
+		.description(description)
         .host(host)
         .basePath(basePath)
         .schemes(schemes)
         .format(options.getFormat())
-        .authConfig(oauth2);
+        .authConfig(oauth2)
+        .tagDescriptions(tagDescriptions);
   }
 
   private List<SpecificationOptions> getAllSpecificationOptions() {


### PR DESCRIPTION
Support configuring description & tag descriptions from pom.xml. (new feature in restdocs-api-spec)