### PR TITLE
chore(*): removing jitpack dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,6 @@
       <url>https://repo.maven.apache.org/maven2</url>
     </repository>
     <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-    <repository>
       <id>jcenter</id>
       <url>https://jcenter.bintray.com</url>
     </repository>
@@ -72,7 +68,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.version>3.3.1</maven.version>
     <maven-plugin-tools.version>3.5.2</maven-plugin-tools.version>
-    <restdocs-api-spec.version>0.8.0</restdocs-api-spec.version>
+    <restdocs-api-spec.version>0.9.0</restdocs-api-spec.version>
     <junit.version>5.2.0</junit.version>
     <assertj.version>3.11.0</assertj.version>
     <mockito.version>2.21.0</mockito.version>


### PR DESCRIPTION
The restdocs-api-spec project has removed its dependency on Jitpack as
of release 0.9.0 so Jitpack should no longer be needed for
restdocs-spec-maven-plugin.

relates to #19