### PR TITLE
feat: use extended format for tag definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,40 @@ There are several other aspects you can optionally configure.  Here is the full 
           <format>YAML</format>
           <filename>openapi-2.0</filename>
           <separatePublicApi>false</separatePublicApi>
+          <tags />
           <oauth2 />
+        </configuration>
+      </execution>
+    </executions>
+  </plugin>
+```
+
+### Tags
+
+By default the plugin will not generate any tags.  You can optionally provide tags using the
+ `<tags />` element.  Here is an example:
+
+```xml
+  <plugin>
+    <groupId>com.github.berkleytechnologyservices.restdocs-spec</groupId>
+    <artifactId>restdocs-spec-maven-plugin</artifactId>
+    <version>${restdocs-spec.version}</version>
+    <executions>
+      <execution>
+        <goals>
+          <goal>generate</goal>
+        </goals>
+        <configuration>
+          <tags>
+            <tag>
+              <name>pets</name>
+              <description>Everything about your Pets</description>
+            </tag>
+            <tag>
+              <name>store</name>
+              <description>Access to Petstore orders</description>
+            </tag>
+          </tags>
         </configuration>
       </execution>
     </executions>

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/ApiDetails.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/ApiDetails.java
@@ -2,7 +2,6 @@ package com.berkleytechnologyservices.restdocs.spec;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 public class ApiDetails {
 
@@ -20,7 +19,7 @@ public class ApiDetails {
   private List<String> schemes;
   private SpecificationFormat format;
   private AuthConfig authConfig;
-  private Map<String, String> tagDescriptions;
+  private List<Tag> tags;
   
   public ApiDetails() {
     this.name = DEFAULT_NAME;
@@ -30,7 +29,7 @@ public class ApiDetails {
     this.schemes = DEFAULT_SCHEMES;
     this.format = DEFAULT_FORMAT;
     this.authConfig = new AuthConfig();
-    this.tagDescriptions = Collections.emptyMap();
+    this.tags = Collections.emptyList();
   }
 
   public String getName() {
@@ -105,12 +104,12 @@ public class ApiDetails {
     return this;
   }
 
-  public Map<String, String> getTagDescriptions() {
-    return tagDescriptions;
+  public List<Tag> getTags() {
+    return tags;
   }
 
-  public ApiDetails tagDescriptions(Map<String, String> tagDescriptions) {
-    this.tagDescriptions = tagDescriptions != null ? tagDescriptions : this.tagDescriptions;
+  public ApiDetails tags(List<Tag> tags) {
+    this.tags = tags != null ? tags : this.tags;
     return this;
   }
 }

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/Tag.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/Tag.java
@@ -1,0 +1,23 @@
+package com.berkleytechnologyservices.restdocs.spec;
+
+public class Tag {
+
+  private String name;
+  private String description;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+}

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/SpecificationGeneratorUtils.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/SpecificationGeneratorUtils.java
@@ -2,8 +2,11 @@ package com.berkleytechnologyservices.restdocs.spec.generator;
 
 import com.berkleytechnologyservices.restdocs.spec.AuthConfig;
 import com.berkleytechnologyservices.restdocs.spec.Scope;
+import com.berkleytechnologyservices.restdocs.spec.Tag;
 import com.epages.restdocs.apispec.model.Oauth2Configuration;
 
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SpecificationGeneratorUtils {
@@ -30,5 +33,10 @@ public class SpecificationGeneratorUtils {
     }
 
     return oauth2Configuration;
+  }
+
+  public static Map<String, String> createTagDescriptionsMap(List<Tag> tags) {
+    return tags.stream()
+        .collect(Collectors.toMap(Tag::getName, Tag::getDescription));
   }
 }

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v2/OpenApi20SpecificationGenerator.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v2/OpenApi20SpecificationGenerator.java
@@ -1,18 +1,14 @@
 package com.berkleytechnologyservices.restdocs.spec.generator.openapi_v2;
 
 import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
-import com.berkleytechnologyservices.restdocs.spec.AuthConfig;
-import com.berkleytechnologyservices.restdocs.spec.Scope;
 import com.berkleytechnologyservices.restdocs.spec.Specification;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGenerator;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorUtils;
-import com.epages.restdocs.apispec.model.Oauth2Configuration;
 import com.epages.restdocs.apispec.model.ResourceModel;
 import com.epages.restdocs.apispec.openapi2.OpenApi20Generator;
 
 import javax.inject.Named;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Named
 public class OpenApi20SpecificationGenerator implements SpecificationGenerator {
@@ -41,7 +37,7 @@ public class OpenApi20SpecificationGenerator implements SpecificationGenerator {
         details.getSchemes(),
         details.getName(),
         details.getDescription(),
-        details.getTagDescriptions(),
+        SpecificationGeneratorUtils.createTagDescriptionsMap(details.getTags()),
         details.getVersion(),
         SpecificationGeneratorUtils.createOauth2Configuration(details.getAuthConfig()),
         details.getFormat().name().toLowerCase()

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGenerator.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGenerator.java
@@ -48,7 +48,7 @@ public class OpenApi30SpecificationGenerator implements SpecificationGenerator {
             servers,
             details.getName(),
             details.getDescription(),
-            details.getTagDescriptions(),
+            SpecificationGeneratorUtils.createTagDescriptionsMap(details.getTags()),
             details.getVersion(),
             SpecificationGeneratorUtils.createOauth2Configuration(details.getAuthConfig()),
             details.getFormat().name().toLowerCase()

--- a/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/GenerateMojo.java
+++ b/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/GenerateMojo.java
@@ -4,6 +4,7 @@ import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
 import com.berkleytechnologyservices.restdocs.spec.AuthConfig;
 import com.berkleytechnologyservices.restdocs.spec.Specification;
 import com.berkleytechnologyservices.restdocs.spec.SpecificationFormat;
+import com.berkleytechnologyservices.restdocs.spec.Tag;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorException;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorFactory;
 import com.epages.restdocs.apispec.model.ResourceModel;
@@ -21,7 +22,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -121,7 +121,7 @@ public class GenerateMojo extends AbstractMojo {
    * No default - if not provided no tags will be created.
    */
   @Parameter
-  private Map<String, String> tagDescriptions;
+  private List<Tag> tags;
 
   private final SnippetReader snippetReader;
   private final SpecificationGeneratorFactory specificationGeneratorFactory;
@@ -222,7 +222,7 @@ public class GenerateMojo extends AbstractMojo {
         .schemes(schemes)
         .format(options.getFormat())
         .authConfig(oauth2)
-        .tagDescriptions(tagDescriptions);
+        .tags(tags);
   }
 
   private List<SpecificationOptions> getAllSpecificationOptions() {


### PR DESCRIPTION
Changing the tag format from:

```xml
  <tagDescriptions>
    <pets>Everything about your Pets</pets>
    <store>Access to Petstore orders</store>
  </tagDescriptions>
```

to:

```xml
  <tags>
    <tag>
      <name>pets</name>
      <description>Everything about your Pets</description>
    </tag>
    <tag>
      <name>store</name>
      <description>Access to Petstore orders</description>
    </tag>
  </tags>
```

This is more verbose but it is consistent with how scopes are defined
and allows for tag names that have whitespace in the name.

closes #24