### PR TITLE
fix: should not fail on unknown properties

### DIFF
--- a/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/SnippetReader.java
+++ b/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/SnippetReader.java
@@ -24,7 +24,7 @@ public class SnippetReader {
 
   public SnippetReader() {
     this(new ObjectMapper()
-            .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .registerModule(new KotlinModule()));
   }
 


### PR DESCRIPTION
The fix for issue #30 disabled `FAIL_ON_IGNORED_PROPERTIES` but what we
really wanted was to disable `FAIL_ON_UNKNOWN_PROPERTIES`.

relates to #30
closes #32