### PR TITLE
fix(openapi3): invalid url when using host:port

### DIFF
--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGenerator.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGenerator.java
@@ -37,7 +37,7 @@ public class OpenApi30SpecificationGenerator implements SpecificationGenerator {
     List<Server> servers = new ArrayList<>();
     for (String scheme : details.getSchemes()) {
       try {
-        URL url = new URL(scheme, details.getHost(), details.getBasePath() == null ? "" : details.getBasePath());
+        URL url = buildUrl(scheme, details.getHost(), details.getBasePath() == null ? "" : details.getBasePath());
         servers.add(new Server().url(url.toString()));
       } catch (MalformedURLException e) {
       	throw new IllegalArgumentException("Invalid server URL", e);
@@ -53,6 +53,17 @@ public class OpenApi30SpecificationGenerator implements SpecificationGenerator {
             SpecificationGeneratorUtils.createOauth2Configuration(details.getAuthConfig()),
             details.getFormat().name().toLowerCase()
     );
+  }
+
+  private URL buildUrl(String scheme, String host, String basePath) throws MalformedURLException {
+    URL url;
+    int indexOfColon = host.indexOf(':');
+    if (indexOfColon > -1 && indexOfColon + 1 < host.length()) {
+      url = new URL(scheme, host.substring(0, indexOfColon), Integer.parseInt(host.substring(indexOfColon + 1)), basePath);
+    } else {
+      url = new URL(scheme, host, basePath);
+    }
+    return url;
   }
 
 }

--- a/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGeneratorTest.java
+++ b/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGeneratorTest.java
@@ -34,37 +34,51 @@ public class OpenApi30SpecificationGeneratorTest {
 
     ApiDetails apiDetails = new ApiDetails();
 
-    ResourceModel model = resource(
-            "book-get",
-            "Get a book by id",
-            "book",
-            request(
-                    "/book/{id}",
-                    HTTPMethod.GET,
-                    list(
-                            requiredParam("id", "The unique identifier for the book.", "NUMBER")
-                    ),
-                    emptyList()
-            ),
-            response(
-                    200,
-                    "application/hal+json",
-                    list(),
-                    list(
-                            field("title", "Title of the book", "STRING"),
-                            field("author", "Author of the book", "STRING"),
-                            field("pages", "Number of pages in the book", "NUMBER")
-                    ),
-                    "The example response.",
-                    new Schema("MyCustomSchemaName")
 
-            )
-    );
-
-    String rawOutput = generator.generate(apiDetails, list(model));
+    String rawOutput = generator.generate(apiDetails, list(getMockResource()));
 
     assertThat(rawOutput)
             .isEqualToNormalizingNewlines(contentOfResource("/mock-specs/default-settings-openapi3.yml"));
+  }
+
+  @Test
+  public void testGenerateHostWithPort() {
+
+    ApiDetails apiDetails = new ApiDetails().host("example.com:8080");
+
+    String rawOutput = generator.generate(apiDetails, list(getMockResource()));
+
+    assertThat(rawOutput)
+      .isEqualToNormalizingNewlines(contentOfResource("/mock-specs/host-with-port-openapi3.yml"));
+  }
+
+  private ResourceModel getMockResource() {
+    return resource(
+      "book-get",
+      "Get a book by id",
+      "book",
+      request(
+        "/book/{id}",
+        HTTPMethod.GET,
+        list(
+          requiredParam("id", "The unique identifier for the book.", "NUMBER")
+        ),
+        emptyList()
+      ),
+      response(
+        200,
+        "application/hal+json",
+        list(),
+        list(
+          field("title", "Title of the book", "STRING"),
+          field("author", "Author of the book", "STRING"),
+          field("pages", "Number of pages in the book", "NUMBER")
+        ),
+        "The example response.",
+        new Schema("MyCustomSchemaName")
+
+      )
+    );
   }
 
   private static String contentOfResource(String resourceName) {

--- a/restdocs-spec-generator/src/test/resources/mock-specs/host-with-port-openapi3.yml
+++ b/restdocs-spec-generator/src/test/resources/mock-specs/host-with-port-openapi3.yml
@@ -1,0 +1,47 @@
+openapi: 3.0.1
+info:
+  title: API Documentation
+  version: 1.0.0
+servers:
+- url: http://example.com:8080
+tags: []
+paths:
+  /book/{id}:
+    get:
+      tags:
+      - book
+      summary: Get a book by id
+      description: Get a book by id
+      operationId: book-get
+      parameters:
+      - name: id
+        in: path
+        description: The unique identifier for the book.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/MyCustomSchemaName'
+              examples:
+                book-get:
+                  value: The example response.
+components:
+  schemas:
+    MyCustomSchemaName:
+      title: MyCustomSchemaName
+      type: object
+      properties:
+        pages:
+          type: number
+          description: Number of pages in the book
+        author:
+          type: string
+          description: Author of the book
+        title:
+          type: string
+          description: Title of the book


### PR DESCRIPTION
The generator for OpenAPI V3 was not taking into account the possibility
that the host contained a port number so it was incorrectly building an
invalid URL.

fixes #85