### PR TITLE
Renovate/restdocs api spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 17
       - name: Build
         run: ./mvnw clean verify -Prun-its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
       - name: Build
         run: ./mvnw clean verify -Prun-its

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <maven.version>3.3.1</maven.version>
     <maven-plugin-tools.version>3.8.1</maven-plugin-tools.version>
     <restdocs-api-spec.version>0.17.1</restdocs-api-spec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.version>3.3.1</maven.version>
     <maven-plugin-tools.version>3.8.1</maven-plugin-tools.version>
-    <restdocs-api-spec.version>0.16.2</restdocs-api-spec.version>
+    <restdocs-api-spec.version>0.17.1</restdocs-api-spec.version>
     <junit.version>5.9.2</junit.version>
     <assertj.version>3.24.2</assertj.version>
     <mockito.version>4.11.0</mockito.version>

--- a/restdocs-spec-generator/pom.xml
+++ b/restdocs-spec-generator/pom.xml
@@ -33,6 +33,10 @@
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-kotlin</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/SpecificationGeneratorFactory.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/SpecificationGeneratorFactory.java
@@ -1,9 +1,12 @@
 package com.berkleytechnologyservices.restdocs.spec.generator;
 
 import com.berkleytechnologyservices.restdocs.spec.Specification;
+import com.berkleytechnologyservices.restdocs.spec.generator.openapi_v2.OpenApi20SpecificationGenerator;
+import com.berkleytechnologyservices.restdocs.spec.generator.openapi_v3.OpenApi30SpecificationGenerator;
+import com.berkleytechnologyservices.restdocs.spec.generator.postman.PostmanCollectionSpecificationGenerator;
 
-import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Inject;
 import java.util.List;
 
 @Named
@@ -11,9 +14,18 @@ public class SpecificationGeneratorFactory {
 
   private final List<SpecificationGenerator> generators;
 
+
   @Inject
-  public SpecificationGeneratorFactory(List<SpecificationGenerator> generators) {
-    this.generators = generators;
+  public SpecificationGeneratorFactory(
+          OpenApi20SpecificationGenerator openApi20SpecificationGenerator,
+          OpenApi30SpecificationGenerator openApi30SpecificationGenerator,
+          PostmanCollectionSpecificationGenerator postmanCollectionSpecificationGenerator
+  ) {
+    this.generators = List.of(
+            openApi20SpecificationGenerator,
+            openApi30SpecificationGenerator,
+            postmanCollectionSpecificationGenerator
+    );
   }
 
   public SpecificationGenerator createGenerator(Specification specification) {

--- a/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/postman/PostmanCollectionSpecificationGeneratorTest.java
+++ b/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/postman/PostmanCollectionSpecificationGeneratorTest.java
@@ -35,7 +35,6 @@ public class PostmanCollectionSpecificationGeneratorTest {
 
     ApiDetails apiDetails = new ApiDetails();
 
-
     String rawOutput = generator.generate(apiDetails, list(getMockResource()));
 
     assertThat(rawOutput)

--- a/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/test/ResourceModels.java
+++ b/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/test/ResourceModels.java
@@ -74,16 +74,16 @@ public final class ResourceModels {
   public static RequestModel request(String path,
                                      HTTPMethod method,
                                      List<ParameterDescriptor> pathParameters,
-                                     List<ParameterDescriptor> requestParameters) {
+                                     List<ParameterDescriptor> queryParameters) {
     return request(
         path,
         method,
         null,
         null,
-        emptyList(),
+        List.of(),
         pathParameters,
-        requestParameters,
-        emptyList(),
+        queryParameters,
+        List.of(),
         null,
         null
     );
@@ -95,7 +95,7 @@ public final class ResourceModels {
                                      SecurityRequirements securityRequirements,
                                      List<HeaderDescriptor> headers,
                                      List<ParameterDescriptor> pathParameters,
-                                     List<ParameterDescriptor> requestParameters,
+                                     List<ParameterDescriptor> queryParameters,
                                      List<? extends FieldDescriptor> requestFields, String example, Schema schema) {
     return new RequestModel(
         path,
@@ -104,7 +104,8 @@ public final class ResourceModels {
         securityRequirements,
         headers,
         pathParameters,
-        requestParameters,
+        queryParameters,
+        List.of(),
         requestFields,
         example,
         schema

--- a/restdocs-spec-maven-plugin/pom.xml
+++ b/restdocs-spec-maven-plugin/pom.xml
@@ -51,6 +51,11 @@
       <groupId>com.epages</groupId>
       <artifactId>restdocs-api-spec-model</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-kotlin</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/restdocs-spec-maven-plugin/src/it/default-settings/snippets/cart-add-product/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/default-settings/snippets/cart-add-product/resource.json
@@ -10,7 +10,8 @@
     "contentType" : "text/uri-list",
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : "http://localhost/products/1",
     "securityRequirements" : null

--- a/restdocs-spec-maven-plugin/src/it/default-settings/snippets/cart-get/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/default-settings/snippets/cart-get/resource.json
@@ -16,7 +16,8 @@
       "type" : "STRING",
       "optional" : false
     } ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : null

--- a/restdocs-spec-maven-plugin/src/it/default-settings/snippets/cart-order/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/default-settings/snippets/cart-order/resource.json
@@ -10,7 +10,8 @@
     "contentType" : null,
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : null

--- a/restdocs-spec-maven-plugin/src/it/default-settings/snippets/carts-create/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/default-settings/snippets/carts-create/resource.json
@@ -10,7 +10,8 @@
     "contentType" : null,
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : null

--- a/restdocs-spec-maven-plugin/src/it/json-format/snippets/cart-add-product/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/json-format/snippets/cart-add-product/resource.json
@@ -10,7 +10,8 @@
     "contentType" : "text/uri-list",
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : "http://localhost/products/1",
     "securityRequirements" : null

--- a/restdocs-spec-maven-plugin/src/it/json-format/snippets/cart-get/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/json-format/snippets/cart-get/resource.json
@@ -16,7 +16,8 @@
       "type" : "STRING",
       "optional" : false
     } ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : {

--- a/restdocs-spec-maven-plugin/src/it/json-format/snippets/cart-order/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/json-format/snippets/cart-order/resource.json
@@ -10,7 +10,8 @@
     "contentType" : null,
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : null

--- a/restdocs-spec-maven-plugin/src/it/json-format/snippets/carts-create/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/json-format/snippets/carts-create/resource.json
@@ -10,7 +10,8 @@
     "contentType" : null,
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : {

--- a/restdocs-spec-maven-plugin/src/it/postman/snippets/cart-add-product/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/postman/snippets/cart-add-product/resource.json
@@ -10,7 +10,8 @@
     "contentType" : "text/uri-list",
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : "http://localhost/products/1",
     "securityRequirements" : null

--- a/restdocs-spec-maven-plugin/src/it/postman/snippets/cart-get/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/postman/snippets/cart-get/resource.json
@@ -16,7 +16,8 @@
       "type" : "STRING",
       "optional" : false
     } ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : {

--- a/restdocs-spec-maven-plugin/src/it/postman/snippets/cart-order/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/postman/snippets/cart-order/resource.json
@@ -10,7 +10,8 @@
     "contentType" : null,
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : null

--- a/restdocs-spec-maven-plugin/src/it/postman/snippets/carts-create/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/postman/snippets/carts-create/resource.json
@@ -10,7 +10,8 @@
     "contentType" : null,
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : {

--- a/restdocs-spec-maven-plugin/src/it/public-api/snippets/cart-add-product/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/public-api/snippets/cart-add-product/resource.json
@@ -10,7 +10,8 @@
     "contentType" : "text/uri-list",
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : "http://localhost/products/1",
     "securityRequirements" : null

--- a/restdocs-spec-maven-plugin/src/it/public-api/snippets/cart-get/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/public-api/snippets/cart-get/resource.json
@@ -16,7 +16,8 @@
       "type" : "STRING",
       "optional" : false
     } ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : {

--- a/restdocs-spec-maven-plugin/src/it/public-api/snippets/cart-order/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/public-api/snippets/cart-order/resource.json
@@ -10,7 +10,8 @@
     "contentType" : null,
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : null

--- a/restdocs-spec-maven-plugin/src/it/public-api/snippets/carts-create/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/public-api/snippets/carts-create/resource.json
@@ -10,7 +10,8 @@
     "contentType" : null,
     "headers" : [ ],
     "pathParameters" : [ ],
-    "requestParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
     "requestFields" : [ ],
     "example" : null,
     "securityRequirements" : {

--- a/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/AbstractGenerateMojo.java
+++ b/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/AbstractGenerateMojo.java
@@ -8,13 +8,11 @@ import com.berkleytechnologyservices.restdocs.spec.Tag;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorException;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorFactory;
 import com.epages.restdocs.apispec.model.ResourceModel;
+import com.google.inject.Inject;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/AbstractGenerateMojo.java
+++ b/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/AbstractGenerateMojo.java
@@ -8,11 +8,11 @@ import com.berkleytechnologyservices.restdocs.spec.Tag;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorException;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorFactory;
 import com.epages.restdocs.apispec.model.ResourceModel;
-import com.google.inject.Inject;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/AggregateMojo.java
+++ b/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/AggregateMojo.java
@@ -9,15 +9,18 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+
 /**
  * This mojo generates a single api specification by aggregating snippet files from all child projects.
  */
+@Named
 @Mojo(name = "aggregate", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, aggregator = true, threadSafe = true)
 public class AggregateMojo extends AbstractGenerateMojo {
 

--- a/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/GenerateMojo.java
+++ b/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/GenerateMojo.java
@@ -8,12 +8,14 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.io.File;
 import java.util.List;
 
 /**
  * This mojo generates an api specification using snippet files.
  */
+@Named
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, threadSafe = true)
 public class GenerateMojo extends AbstractGenerateMojo {
 

--- a/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/SnippetReader.java
+++ b/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/SnippetReader.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.kotlin.KotlinModule;
 import org.apache.maven.plugin.MojoExecutionException;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.File;
 import java.io.IOException;
@@ -22,6 +23,7 @@ public class SnippetReader {
 
   private final ObjectMapper objectMapper;
 
+  @Inject
   public SnippetReader() {
     this(new ObjectMapper()
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)


### PR DESCRIPTION
Hey there!

I finished the bot job.
I have some notions here.

1. restdocs-api-spec v0.17.1 requires java 17 as minimal so I upgraded it.
2. I had problems with guice injection of collection into SpecificationGeneratorFactory with java 17. So this is the only solution that works. 
3. To build it local you should have JAVA_HOME that refers to java 17 due to maven-invoker-plugin (integration tests).

Our team likes this tool, but it's the last point of our migration to java 17 and spring boot 3. So we can't wait of new updates from sisu and guice.  This my version is stable one. 

I suggest to tag next version as 1.0 due to breaking changes. 

