### PR TITLE
chore(deps): update restdocs-api-spec to v0.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <maven.version>3.3.1</maven.version>
     <maven-plugin-tools.version>3.9.0</maven-plugin-tools.version>
-    <restdocs-api-spec.version>0.17.1</restdocs-api-spec.version>
+    <restdocs-api-spec.version>0.19.0</restdocs-api-spec.version>
     <junit.version>5.10.0</junit.version>
     <assertj.version>3.24.2</assertj.version>
     <mockito.version>5.6.0</mockito.version>

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/ApiDetails.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/ApiDetails.java
@@ -2,6 +2,7 @@ package com.berkleytechnologyservices.restdocs.spec;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public class ApiDetails {
 
@@ -20,6 +21,8 @@ public class ApiDetails {
   private SpecificationFormat format;
   private AuthConfig authConfig;
   private List<Tag> tags;
+
+  private Contact contact;
   
   public ApiDetails() {
     this.name = DEFAULT_NAME;
@@ -30,6 +33,7 @@ public class ApiDetails {
     this.format = DEFAULT_FORMAT;
     this.authConfig = new AuthConfig();
     this.tags = Collections.emptyList();
+    this.contact = null;
   }
 
   public String getName() {
@@ -110,6 +114,15 @@ public class ApiDetails {
 
   public ApiDetails tags(List<Tag> tags) {
     this.tags = tags != null ? tags : this.tags;
+    return this;
+  }
+
+  public Optional<Contact> getContact() {
+    return Optional.ofNullable(contact);
+  }
+
+  public ApiDetails contact(Contact contact) {
+    this.contact = contact;
     return this;
   }
 }

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/Contact.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/Contact.java
@@ -1,0 +1,32 @@
+package com.berkleytechnologyservices.restdocs.spec;
+
+public class Contact {
+
+  private String name;
+  private String email;
+  private String url;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+}

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGenerator.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGenerator.java
@@ -1,6 +1,7 @@
 package com.berkleytechnologyservices.restdocs.spec.generator.openapi_v3;
 
 import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
+import com.berkleytechnologyservices.restdocs.spec.Contact;
 import com.berkleytechnologyservices.restdocs.spec.Specification;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGenerator;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorException;
@@ -43,7 +44,8 @@ public class OpenApi30SpecificationGenerator implements SpecificationGenerator {
             SpecificationGeneratorUtils.createTagDescriptionsMap(details.getTags()),
             details.getVersion(),
             SpecificationGeneratorUtils.createOauth2Configuration(details.getAuthConfig()),
-            details.getFormat().name().toLowerCase()
+            details.getFormat().name().toLowerCase(),
+            details.getContact().map(this::toSwaggerContact).orElse(null)
     );
   }
 
@@ -58,5 +60,10 @@ public class OpenApi30SpecificationGenerator implements SpecificationGenerator {
       }
     }
     return servers;
+  }
+
+  private io.swagger.v3.oas.models.info.Contact toSwaggerContact(Contact contact) {
+    io.swagger.v3.oas.models.info.Contact swaggerContact = new io.swagger.v3.oas.models.info.Contact();
+    return swaggerContact.name(contact.getName()).email(contact.getEmail()).url(contact.getUrl());
   }
 }

--- a/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGeneratorTest.java
+++ b/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGeneratorTest.java
@@ -1,6 +1,7 @@
 package com.berkleytechnologyservices.restdocs.spec.generator.openapi_v3;
 
 import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
+import com.berkleytechnologyservices.restdocs.spec.Contact;
 import com.berkleytechnologyservices.restdocs.spec.Specification;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorException;
 import com.epages.restdocs.apispec.model.HTTPMethod;
@@ -47,6 +48,21 @@ public class OpenApi30SpecificationGeneratorTest {
 
     assertThat(rawOutput)
       .isEqualToNormalizingNewlines(contentOfResource("/mock-specs/openapi3/host-with-port.yml"));
+  }
+
+  @Test
+  public void testGenerateContact() throws SpecificationGeneratorException {
+    Contact contact = new Contact();
+    contact.setName("John Doe");
+    contact.setEmail("john@example.com");
+    contact.setUrl("https://john.example.com");
+
+    ApiDetails apiDetails = new ApiDetails().contact(contact);
+
+    String rawOutput = generator.generate(apiDetails, list(getMockResource()));
+
+    assertThat(rawOutput)
+        .isEqualToNormalizingNewlines(contentOfResource("/mock-specs/openapi3/contact.yml"));
   }
 
   private ResourceModel getMockResource() {

--- a/restdocs-spec-generator/src/test/resources/mock-specs/openapi2/default-settings.yml
+++ b/restdocs-spec-generator/src/test/resources/mock-specs/openapi2/default-settings.yml
@@ -27,10 +27,14 @@ paths:
           description: ""
           examples: {}
           schema:
-            $ref: '#/definitions/book_id-1050330160'
+            $ref: '#/definitions/book_id-1528421121'
 definitions:
-  book_id-1050330160:
+  book_id-1528421121:
     type: object
+    required:
+    - author
+    - pages
+    - title
     properties:
       pages:
         type: number

--- a/restdocs-spec-generator/src/test/resources/mock-specs/openapi3/contact.yml
+++ b/restdocs-spec-generator/src/test/resources/mock-specs/openapi3/contact.yml
@@ -1,6 +1,10 @@
 openapi: 3.0.1
 info:
   title: API Documentation
+  contact:
+    name: John Doe
+    url: https://john.example.com
+    email: john@example.com
   version: 1.0.0
 servers:
 - url: http://localhost

--- a/restdocs-spec-generator/src/test/resources/mock-specs/openapi3/host-with-port.yml
+++ b/restdocs-spec-generator/src/test/resources/mock-specs/openapi3/host-with-port.yml
@@ -34,6 +34,10 @@ components:
   schemas:
     MyCustomSchemaName:
       title: MyCustomSchemaName
+      required:
+      - author
+      - pages
+      - title
       type: object
       properties:
         pages:

--- a/restdocs-spec-maven-plugin/src/it/openapi-3.0/pom.xml
+++ b/restdocs-spec-maven-plugin/src/it/openapi-3.0/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.berkleytechnologyservices.restdocs-spec.it</groupId>
+  <artifactId>default-settings-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Verify the default settings.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.basedir}/target/generated-snippets</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>snippets</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <specification>OPENAPI_V3</specification>
+              <contact>
+                <name>John Doe</name>
+                <email>john@example.com</email>
+                <url>https://john.example.com</url>
+              </contact>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/restdocs-spec-maven-plugin/src/it/openapi-3.0/snippets/cart-add-product/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/openapi-3.0/snippets/cart-add-product/resource.json
@@ -1,0 +1,26 @@
+{
+  "operationId" : "cart-add-product",
+  "summary" : "Add products to a cart",
+  "description" : "Add products to a cart",
+  "privateResource" : false,
+  "deprecated" : false,
+  "request" : {
+    "path" : "/carts/{id}/products",
+    "method" : "POST",
+    "contentType" : "text/uri-list",
+    "headers" : [ ],
+    "pathParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
+    "requestFields" : [ ],
+    "example" : "http://localhost/products/1",
+    "securityRequirements" : null
+  },
+  "response" : {
+    "status" : 200,
+    "contentType" : "application/hal+json",
+    "headers" : [ ],
+    "responseFields" : [ ],
+    "example" : "{\r\n  \"total\" : 49.99,\r\n  \"products\" : [ {\r\n    \"quantity\" : 1,\r\n    \"product\" : {\r\n      \"name\" : \"Fancy pants\",\r\n      \"price\" : 49.99\r\n    },\r\n    \"_links\" : {\r\n      \"product\" : {\r\n        \"href\" : \"http://localhost:8080/products/1\"\r\n      }\r\n    }\r\n  } ],\r\n  \"_links\" : {\r\n    \"self\" : {\r\n      \"href\" : \"http://localhost:8080/carts/1\"\r\n    },\r\n    \"order\" : {\r\n      \"href\" : \"http://localhost:8080/carts/1/order\"\r\n    }\r\n  }\r\n}"
+  }
+}

--- a/restdocs-spec-maven-plugin/src/it/openapi-3.0/snippets/cart-get/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/openapi-3.0/snippets/cart-get/resource.json
@@ -1,0 +1,68 @@
+{
+  "operationId" : "cart-get",
+  "summary" : "Get a cart by id",
+  "description" : "Get a cart by id",
+  "privateResource" : false,
+  "deprecated" : false,
+  "request" : {
+    "path" : "/carts/{id}",
+    "method" : "GET",
+    "contentType" : null,
+    "headers" : [ ],
+    "pathParameters" : [ {
+      "name" : "id",
+      "description" : "the cart id",
+      "ignored" : false,
+      "type" : "STRING",
+      "optional" : false
+    } ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
+    "requestFields" : [ ],
+    "example" : null,
+    "securityRequirements" : null
+  },
+  "response" : {
+    "status" : 200,
+    "contentType" : "application/hal+json",
+    "headers" : [ ],
+    "responseFields" : [ {
+      "description" : "Total amount of the cart.",
+      "ignored" : false,
+      "path" : "total",
+      "type" : "NUMBER",
+      "optional" : false
+    }, {
+      "description" : "The product line item of the cart.",
+      "ignored" : false,
+      "path" : "products",
+      "type" : "ARRAY",
+      "optional" : false
+    }, {
+      "description" : "Link to the product.",
+      "ignored" : false,
+      "path" : "products[]._links.product",
+      "type" : "OBJECT",
+      "optional" : false
+    }, {
+      "description" : "The quantity of the line item.",
+      "ignored" : false,
+      "path" : "products[].quantity",
+      "type" : "NUMBER",
+      "optional" : false
+    }, {
+      "description" : "The product the line item relates to.",
+      "ignored" : false,
+      "path" : "products[].product",
+      "type" : "OBJECT",
+      "optional" : false
+    }, {
+      "description" : "Links section.",
+      "ignored" : false,
+      "path" : "_links",
+      "type" : "OBJECT",
+      "optional" : false
+    } ],
+    "example" : "{\r\n  \"total\" : 49.99,\r\n  \"products\" : [ {\r\n    \"quantity\" : 1,\r\n    \"product\" : {\r\n      \"name\" : \"Fancy pants\",\r\n      \"price\" : 49.99\r\n    },\r\n    \"_links\" : {\r\n      \"product\" : {\r\n        \"href\" : \"http://localhost:8080/products/2\"\r\n      }\r\n    }\r\n  } ],\r\n  \"_links\" : {\r\n    \"self\" : {\r\n      \"href\" : \"http://localhost:8080/carts/2\"\r\n    },\r\n    \"order\" : {\r\n      \"href\" : \"http://localhost:8080/carts/2/order\"\r\n    }\r\n  }\r\n}"
+  }
+}

--- a/restdocs-spec-maven-plugin/src/it/openapi-3.0/snippets/cart-order/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/openapi-3.0/snippets/cart-order/resource.json
@@ -1,0 +1,26 @@
+{
+  "operationId" : "cart-order",
+  "summary" : "Order a cart",
+  "description" : "Order a cart",
+  "privateResource" : false,
+  "deprecated" : false,
+  "request" : {
+    "path" : "/carts/{id}/order",
+    "method" : "POST",
+    "contentType" : null,
+    "headers" : [ ],
+    "pathParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
+    "requestFields" : [ ],
+    "example" : null,
+    "securityRequirements" : null
+  },
+  "response" : {
+    "status" : 200,
+    "contentType" : "application/hal+json",
+    "headers" : [ ],
+    "responseFields" : [ ],
+    "example" : "{\r\n  \"total\" : 49.99,\r\n  \"products\" : [ {\r\n    \"quantity\" : 1,\r\n    \"product\" : {\r\n      \"name\" : \"Fancy pants\",\r\n      \"price\" : 49.99\r\n    },\r\n    \"_links\" : {\r\n      \"product\" : {\r\n        \"href\" : \"http://localhost:8080/products/3\"\r\n      }\r\n    }\r\n  } ],\r\n  \"_links\" : {\r\n    \"self\" : {\r\n      \"href\" : \"http://localhost:8080/carts/3\"\r\n    }\r\n  }\r\n}"
+  }
+}

--- a/restdocs-spec-maven-plugin/src/it/openapi-3.0/snippets/carts-create/resource.json
+++ b/restdocs-spec-maven-plugin/src/it/openapi-3.0/snippets/carts-create/resource.json
@@ -1,0 +1,26 @@
+{
+  "operationId" : "carts-create",
+  "summary" : "Create a cart",
+  "description" : "Create a cart",
+  "privateResource" : false,
+  "deprecated" : false,
+  "request" : {
+    "path" : "/carts",
+    "method" : "POST",
+    "contentType" : null,
+    "headers" : [ ],
+    "pathParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
+    "requestFields" : [ ],
+    "example" : null,
+    "securityRequirements" : null
+  },
+  "response" : {
+    "status" : 201,
+    "contentType" : "application/hal+json",
+    "headers" : [ ],
+    "responseFields" : [ ],
+    "example" : "{\r\n  \"total\" : 0,\r\n  \"products\" : [ ],\r\n  \"_links\" : {\r\n    \"self\" : {\r\n      \"href\" : \"http://localhost:8080/carts/4\"\r\n    },\r\n    \"order\" : {\r\n      \"href\" : \"http://localhost:8080/carts/4/order\"\r\n    }\r\n  }\r\n}"
+  }
+}

--- a/restdocs-spec-maven-plugin/src/it/openapi-3.0/verify.groovy
+++ b/restdocs-spec-maven-plugin/src/it/openapi-3.0/verify.groovy
@@ -1,0 +1,1 @@
+assert new File(basedir, "target/restdocs-spec/openapi-3.0.yml").exists() : 'Spec file was not found at the expected location'

--- a/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/AbstractGenerateMojo.java
+++ b/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/AbstractGenerateMojo.java
@@ -2,6 +2,7 @@ package com.berkleytechnologyservices.restdocs.mojo;
 
 import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
 import com.berkleytechnologyservices.restdocs.spec.AuthConfig;
+import com.berkleytechnologyservices.restdocs.spec.Contact;
 import com.berkleytechnologyservices.restdocs.spec.Specification;
 import com.berkleytechnologyservices.restdocs.spec.SpecificationFormat;
 import com.berkleytechnologyservices.restdocs.spec.Tag;
@@ -114,6 +115,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   @Parameter
   private List<Tag> tags;
 
+  @Parameter
+  private Contact contact;
+
   private final SpecificationGeneratorFactory specificationGeneratorFactory;
 
   @Inject
@@ -202,13 +206,14 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
     return new ApiDetails()
         .name(name)
         .version(version)
-		.description(description)
+        .description(description)
         .host(host)
         .basePath(basePath)
         .schemes(schemes)
         .format(options.getFormat())
         .authConfig(oauth2)
-        .tags(tags);
+        .tags(tags)
+        .contact(contact);
   }
 
   private List<SpecificationOptions> getAllSpecificationOptions() {


### PR DESCRIPTION
Adds support for `contact` object in the mojo parameters.
