### PR TITLE
Keep order of hosts and add description to Host

### DIFF
--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/ApiDetails.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/ApiDetails.java
@@ -3,7 +3,6 @@ package com.berkleytechnologyservices.restdocs.spec;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public class ApiDetails {
 
@@ -16,7 +15,7 @@ public class ApiDetails {
   private String name;
   private String version;
   private String description;
-  private Set<String> hosts;
+  private List<Host> hosts;
   private String basePath;
   private List<String> schemes;
   private SpecificationFormat format;
@@ -28,7 +27,7 @@ public class ApiDetails {
   public ApiDetails() {
     this.name = DEFAULT_NAME;
     this.version = DEFAULT_VERSION;
-    this.hosts = Collections.singleton(DEFAULT_HOST);
+    this.hosts = Collections.singletonList(createDefaultHost());
     this.basePath = null;
     this.schemes = DEFAULT_SCHEMES;
     this.format = DEFAULT_FORMAT;
@@ -64,17 +63,21 @@ public class ApiDetails {
     return this;
   }
 
-  public Set<String> getHosts() {
+  public List<Host> getHosts() {
     return hosts;
   }
 
   public String getHost() {
-    return getHosts().stream().findFirst().orElseThrow();
+    return getHosts().get(0).getValue();
   }
 
-  public ApiDetails hosts(Set<String> hosts) {
-    this.hosts = (hosts != null && !hosts.isEmpty()) ? hosts : Collections.singleton(DEFAULT_HOST);
+  public ApiDetails hosts(List<Host> hosts) {
+    this.hosts = (hosts != null && !hosts.isEmpty()) ? hosts : Collections.singletonList(createDefaultHost());
     return this;
+  }
+
+  private Host createDefaultHost() {
+    return new Host(DEFAULT_HOST);
   }
 
   public String getBasePath() {

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/Host.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/Host.java
@@ -1,0 +1,34 @@
+package com.berkleytechnologyservices.restdocs.spec;
+
+public class Host {
+  private String value;
+  private String description;
+
+  public Host() {
+  }
+
+  public Host(String value) {
+    this(value, null);
+  }
+
+  public Host(String value, String description) {
+    this.value = value;
+    this.description = description;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+}

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGenerator.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGenerator.java
@@ -2,6 +2,7 @@ package com.berkleytechnologyservices.restdocs.spec.generator.openapi_v3;
 
 import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
 import com.berkleytechnologyservices.restdocs.spec.Contact;
+import com.berkleytechnologyservices.restdocs.spec.Host;
 import com.berkleytechnologyservices.restdocs.spec.Specification;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGenerator;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorException;
@@ -54,9 +55,12 @@ public class OpenApi30SpecificationGenerator implements SpecificationGenerator {
 
     for (String scheme : details.getSchemes()) {
       try {
-        for (String host : details.getHosts()) {
-          URL url = SpecificationGeneratorUtils.createBaseUrl(scheme, host, details.getBasePath() == null ? "" : details.getBasePath());
-          servers.add(new Server().url(url.toString()));
+        for (Host host : details.getHosts()) {
+          URL url = SpecificationGeneratorUtils.createBaseUrl(scheme, host.getValue(), details.getBasePath() == null ? "" : details.getBasePath());
+          Server server = new Server();
+          server.url(url.toString());
+          server.description(host.getDescription());
+          servers.add(server);
         }
       } catch (MalformedURLException e) {
         throw new SpecificationGeneratorException("Unable to build server url.", e);

--- a/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/postman/PostmanCollectionSpecificationGenerator.java
+++ b/restdocs-spec-generator/src/main/java/com/berkleytechnologyservices/restdocs/spec/generator/postman/PostmanCollectionSpecificationGenerator.java
@@ -61,7 +61,7 @@ public class PostmanCollectionSpecificationGenerator implements SpecificationGen
     }
 
     try {
-      return SpecificationGeneratorUtils.createBaseUrl(details.getSchemes().get(0), details.getHosts().iterator().next(), details.getBasePath()).toString();
+      return SpecificationGeneratorUtils.createBaseUrl(details.getSchemes().get(0), details.getHosts().get(0).getValue(), details.getBasePath()).toString();
     } catch (MalformedURLException e) {
       throw new SpecificationGeneratorException("Unable to build base url.", e);
     }

--- a/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGeneratorTest.java
+++ b/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/openapi_v3/OpenApi30SpecificationGeneratorTest.java
@@ -2,6 +2,7 @@ package com.berkleytechnologyservices.restdocs.spec.generator.openapi_v3;
 
 import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
 import com.berkleytechnologyservices.restdocs.spec.Contact;
+import com.berkleytechnologyservices.restdocs.spec.Host;
 import com.berkleytechnologyservices.restdocs.spec.Specification;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorException;
 import com.epages.restdocs.apispec.model.HTTPMethod;
@@ -44,7 +45,7 @@ public class OpenApi30SpecificationGeneratorTest {
   @Test
   public void testGenerateHostWithPort() throws SpecificationGeneratorException {
 
-    ApiDetails apiDetails = new ApiDetails().hosts(Collections.singleton("example.com:8080"));
+    ApiDetails apiDetails = new ApiDetails().hosts(Collections.singletonList(new Host("example.com:8080")));
 
     String rawOutput = generator.generate(apiDetails, list(getMockResource()));
 

--- a/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/postman/PostmanCollectionSpecificationGeneratorTest.java
+++ b/restdocs-spec-generator/src/test/java/com/berkleytechnologyservices/restdocs/spec/generator/postman/PostmanCollectionSpecificationGeneratorTest.java
@@ -1,6 +1,7 @@
 package com.berkleytechnologyservices.restdocs.spec.generator.postman;
 
 import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
+import com.berkleytechnologyservices.restdocs.spec.Host;
 import com.berkleytechnologyservices.restdocs.spec.Specification;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorException;
 import com.epages.restdocs.apispec.model.HTTPMethod;
@@ -12,11 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 
-import static com.berkleytechnologyservices.restdocs.spec.generator.test.ResourceModels.field;
-import static com.berkleytechnologyservices.restdocs.spec.generator.test.ResourceModels.request;
-import static com.berkleytechnologyservices.restdocs.spec.generator.test.ResourceModels.requiredParam;
-import static com.berkleytechnologyservices.restdocs.spec.generator.test.ResourceModels.resource;
-import static com.berkleytechnologyservices.restdocs.spec.generator.test.ResourceModels.response;
+import static com.berkleytechnologyservices.restdocs.spec.generator.test.ResourceModels.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
 import static org.assertj.core.util.Lists.emptyList;
@@ -46,7 +43,7 @@ public class PostmanCollectionSpecificationGeneratorTest {
   @Test
   public void testGenerateHostWithPort() throws SpecificationGeneratorException {
 
-    ApiDetails apiDetails = new ApiDetails().hosts(Collections.singleton("example.com:8080"));
+    ApiDetails apiDetails = new ApiDetails().hosts(Collections.singletonList(new Host("example.com:8080")));
 
     String rawOutput = generator.generate(apiDetails, list(getMockResource()));
 

--- a/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/AbstractGenerateMojo.java
+++ b/restdocs-spec-maven-plugin/src/main/java/com/berkleytechnologyservices/restdocs/mojo/AbstractGenerateMojo.java
@@ -1,11 +1,6 @@
 package com.berkleytechnologyservices.restdocs.mojo;
 
-import com.berkleytechnologyservices.restdocs.spec.ApiDetails;
-import com.berkleytechnologyservices.restdocs.spec.AuthConfig;
-import com.berkleytechnologyservices.restdocs.spec.Contact;
-import com.berkleytechnologyservices.restdocs.spec.Specification;
-import com.berkleytechnologyservices.restdocs.spec.SpecificationFormat;
-import com.berkleytechnologyservices.restdocs.spec.Tag;
+import com.berkleytechnologyservices.restdocs.spec.*;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorException;
 import com.berkleytechnologyservices.restdocs.spec.generator.SpecificationGeneratorFactory;
 import com.epages.restdocs.apispec.model.ResourceModel;
@@ -21,7 +16,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -53,7 +47,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * More hosts to specify (OpenAPI 3.0)
    */
   @Parameter
-  private Set<String> hosts;
+  private List<Host> hosts;
 
   /**
    * Host
@@ -214,7 +208,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .name(name)
         .version(version)
         .description(description)
-        .hosts((hosts == null || hosts.isEmpty()) ? Collections.singleton(host) : hosts)
+        .hosts((hosts == null || hosts.isEmpty()) ? Collections.singletonList(new Host(host)) : hosts)
         .basePath(basePath)
         .schemes(schemes)
         .format(options.getFormat())


### PR DESCRIPTION
- keep list of hosts in the generated openapi v3 json in the order as it is defined in plugin configuration
- possibility to add description to host